### PR TITLE
Networking/ping,data compression,transform interpolation

### DIFF
--- a/Assets/Scripts/Networking/ByteSerializer.cs
+++ b/Assets/Scripts/Networking/ByteSerializer.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace MastersOfTempest.Networking
+{
+    public class ByteSerializer
+    {
+
+        /// <summary>
+        /// Returns byte array representation of a struct.
+        /// Make sure that strings have a maximal size e.g. [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 100)]
+        /// </summary>
+        /// <typeparam name="T">The type of the struct</typeparam>
+        /// <param name="t">The struct instance</param>
+        /// <returns></returns>
+        public static byte[] GetBytes<T>(T t)
+        {
+            int size = Marshal.SizeOf(t);
+            byte[] data = new byte[size];
+
+            IntPtr ptr = Marshal.AllocHGlobal(size);
+            Marshal.StructureToPtr(t, ptr, true);
+            Marshal.Copy(ptr, data, 0, size);
+            Marshal.FreeHGlobal(ptr);
+
+            return data;
+        }
+
+        /// <summary>
+        /// Returns struct instance representation from a byte array.
+        /// </summary>
+        /// <typeparam name="T">The type of the struct</typeparam>
+        /// <param name="data">The bytes that represent the struct</param>
+        /// <returns></returns>
+        public static T FromBytes<T> (byte[] data)
+        {
+            int size = Marshal.SizeOf(typeof(T));
+
+            IntPtr ptr = Marshal.AllocHGlobal(size);
+            Marshal.Copy(data, 0, ptr, size);
+            T t = (T)Marshal.PtrToStructure(ptr, typeof(T));
+            Marshal.FreeHGlobal(ptr);
+
+            return t;
+        }
+    }
+}

--- a/Assets/Scripts/Networking/ByteSerializer.cs.meta
+++ b/Assets/Scripts/Networking/ByteSerializer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 52bcbf18c3db26b42a989cbe27a38fdb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Networking/ClientManager.cs
+++ b/Assets/Scripts/Networking/ClientManager.cs
@@ -191,6 +191,11 @@ namespace MastersOfTempest.Networking
             SendToClient(client.Lobby.Owner, data, serverMessagesOffset + (int)networkMessageType, sendType);
         }
 
+        public int GetClientCount ()
+        {
+            return client.Lobby.NumMembers;
+        }
+
         void OnDestroy()
         {
             if (client != null)

--- a/Assets/Scripts/Networking/ClientManager.cs
+++ b/Assets/Scripts/Networking/ClientManager.cs
@@ -20,8 +20,8 @@ namespace MastersOfTempest.Networking
         public bool debugServerMessages = false;
 
         // Dynamically let other classes subscribe to these events
-        public Dictionary<NetworkMessageType, System.Action<string, ulong>> clientMessageEvents;
-        public Dictionary<NetworkMessageType, System.Action<string, ulong>> serverMessageEvents;
+        public Dictionary<NetworkMessageType, System.Action<byte[], ulong>> clientMessageEvents;
+        public Dictionary<NetworkMessageType, System.Action<byte[], ulong>> serverMessageEvents;
 
         private Client client;
         private int serverMessagesOffset = 0;
@@ -68,8 +68,8 @@ namespace MastersOfTempest.Networking
             }
 
             // Create all the actions for incoming network messages
-            clientMessageEvents = new Dictionary<NetworkMessageType, System.Action<string, ulong>>();
-            serverMessageEvents = new Dictionary<NetworkMessageType, System.Action<string, ulong>>();
+            clientMessageEvents = new Dictionary<NetworkMessageType, System.Action<byte[], ulong>>();
+            serverMessageEvents = new Dictionary<NetworkMessageType, System.Action<byte[], ulong>>();
 
             System.Array types = System.Enum.GetValues(typeof(NetworkMessageType));
             serverMessagesOffset = types.Length;
@@ -79,11 +79,11 @@ namespace MastersOfTempest.Networking
             {
                 // Listen to messages for the client
                 client.Networking.SetListenChannel((int)type, true);
-                clientMessageEvents[type] = new System.Action<string, ulong>(DebugClientMessageEvent);
+                clientMessageEvents[type] = new System.Action<byte[], ulong>(DebugClientMessageEvent);
 
                 // Listen to all messages for the server with an offset -> know which messages are for the server
                 client.Networking.SetListenChannel(serverMessagesOffset + (int)type, true);
-                serverMessageEvents[type] = new System.Action<string, ulong>(DebugServerMessageEvent);
+                serverMessageEvents[type] = new System.Action<byte[], ulong>(DebugServerMessageEvent);
             }
 
             client.Networking.OnIncomingConnection += OnIncomingConnection;
@@ -101,19 +101,21 @@ namespace MastersOfTempest.Networking
             }
         }
 
-        void DebugClientMessageEvent(string message, ulong steamID)
+        void DebugClientMessageEvent(byte[] data, ulong steamID)
         {
             if (debugClientMessages)
             {
-                Debug.Log("Client received message from " + steamID + ":\n" + message);
+                string message = System.Text.Encoding.UTF8.GetString(data);
+                Debug.Log("Client received " + data.Length + " bytes from " + steamID + ":\n" + message);
             }
         }
 
-        void DebugServerMessageEvent(string message, ulong steamID)
+        void DebugServerMessageEvent(byte[] data, ulong steamID)
         {
             if (debugServerMessages)
             {
-                Debug.Log("Server received message from " + steamID + ":\n" + message);
+                string message = System.Text.Encoding.UTF8.GetString(data);
+                Debug.Log("Server received " + data.Length + " bytes from " + steamID + ":\n" + message);
             }
         }
 
@@ -131,19 +133,20 @@ namespace MastersOfTempest.Networking
         // This is where all the messages are received and delegated to the respective events
         void OnP2PData(ulong steamID, byte[] data, int dataLength, int channel)
         {
-            string message = System.Text.Encoding.UTF8.GetString(data, 0, dataLength);
+            byte[] trimmedData = new byte[dataLength];
+            System.Array.Copy(data, trimmedData, dataLength);
 
             if (channel < serverMessagesOffset)
             {
                 // The message is for the client
                 NetworkMessageType messageType = (NetworkMessageType)channel;
-                clientMessageEvents[messageType].Invoke(message, steamID);
+                clientMessageEvents[messageType].Invoke(trimmedData, steamID);
             }
             else
             {
                 // The message is for the server (which is running on this client)
                 NetworkMessageType messageType = (NetworkMessageType)(channel - serverMessagesOffset);
-                serverMessageEvents[messageType].Invoke(message, steamID);
+                serverMessageEvents[messageType].Invoke(trimmedData, steamID);
             }
         }
 
@@ -163,16 +166,15 @@ namespace MastersOfTempest.Networking
             }
         }
 
-        public void SendToClient(ulong steamID, string message, NetworkMessageType networkMessageType, Facepunch.Steamworks.Networking.SendType sendType)
+        public void SendToClient(ulong steamID, byte[] data, NetworkMessageType networkMessageType, Facepunch.Steamworks.Networking.SendType sendType)
         {
-            SendToClient(steamID, System.Text.Encoding.UTF8.GetBytes(message), (int)networkMessageType, sendType);
+            SendToClient(steamID, data, (int)networkMessageType, sendType);
         }
 
-        public void SendToAllClients(string message, NetworkMessageType networkMessageType, Facepunch.Steamworks.Networking.SendType sendType)
+        public void SendToAllClients(byte[] data, NetworkMessageType networkMessageType, Facepunch.Steamworks.Networking.SendType sendType)
         {
             if (client != null)
             {
-                byte[] data = System.Text.Encoding.UTF8.GetBytes(message);
                 ulong[] lobbyMemberIDs = client.Lobby.GetMemberIDs();
 
                 foreach (ulong steamID in lobbyMemberIDs)
@@ -182,11 +184,11 @@ namespace MastersOfTempest.Networking
             }
         }
 
-        public void SendToServer(string message, NetworkMessageType networkMessageType, Facepunch.Steamworks.Networking.SendType sendType)
+        public void SendToServer(byte[] data, NetworkMessageType networkMessageType, Facepunch.Steamworks.Networking.SendType sendType)
         {
             // Messages for the server are sent on a different channel than messages for a client
             // This way the client knows if the incoming message is for him as a client or him as a server
-            SendToClient(client.Lobby.Owner, System.Text.Encoding.UTF8.GetBytes(message), serverMessagesOffset + (int)networkMessageType, sendType);
+            SendToClient(client.Lobby.Owner, data, serverMessagesOffset + (int)networkMessageType, sendType);
         }
 
         void OnDestroy()

--- a/Assets/Scripts/Networking/GameClient.cs
+++ b/Assets/Scripts/Networking/GameClient.cs
@@ -22,9 +22,9 @@ namespace MastersOfTempest.Networking
             ClientManager.Instance.clientMessageEvents[NetworkMessageType.DestroyServerObject] += OnMessageDestroyServerObject;
             ClientManager.Instance.clientMessageEvents[NetworkMessageType.PingPong] += OnMessagePingPong;
 
-            // Send a message to start the server
-            byte[] data = System.Text.Encoding.UTF8.GetBytes("StartServer");
-            ClientManager.Instance.SendToServer(data, NetworkMessageType.StartServer, Facepunch.Steamworks.Networking.SendType.Reliable);
+            // Send a message to initialize the server
+            byte[] data = System.Text.Encoding.UTF8.GetBytes("InitializeServer");
+            ClientManager.Instance.SendToServer(data, NetworkMessageType.InitializeServer, Facepunch.Steamworks.Networking.SendType.Reliable);
 
             // Wait a bit before sending the message
             lastPingTime = Time.time + pingsPerSec;

--- a/Assets/Scripts/Networking/LobbyChat.cs
+++ b/Assets/Scripts/Networking/LobbyChat.cs
@@ -16,14 +16,16 @@ namespace MastersOfTempest.Networking
             ClientManager.Instance.clientMessageEvents[NetworkMessageType.LobbyChat] += OnMessageLobbyChat;
         }
 
-        void OnMessageLobbyChat(string message, ulong steamID)
+        void OnMessageLobbyChat(byte[] data, ulong steamID)
         {
+            string message = System.Text.Encoding.UTF8.GetString(data);
             textChat.text += "<color=grey>[" + Client.Instance.Friends.Get(steamID).Name + "]: </color>" + message + "\n";
         }
 
         public void SendChatMessage()
         {
-            ClientManager.Instance.SendToAllClients(inputFieldChat.text, NetworkMessageType.LobbyChat, Facepunch.Steamworks.Networking.SendType.Reliable);
+            byte[] data = System.Text.Encoding.UTF8.GetBytes(inputFieldChat.text);
+            ClientManager.Instance.SendToAllClients(data, NetworkMessageType.LobbyChat, Facepunch.Steamworks.Networking.SendType.Reliable);
 
             inputFieldChat.text = "";
             inputFieldChat.ActivateInputField();

--- a/Assets/Scripts/Networking/LobbyManager.cs
+++ b/Assets/Scripts/Networking/LobbyManager.cs
@@ -78,7 +78,8 @@ namespace MastersOfTempest.Networking
                         if (everyoneReady)
                         {
                             // Send the game start message only once
-                            ClientManager.Instance.SendToAllClients("Start Game", NetworkMessageType.LobbyStartGame, Facepunch.Steamworks.Networking.SendType.Reliable);
+                            byte[] data = System.Text.Encoding.UTF8.GetBytes("LobbyStartGame");
+                            ClientManager.Instance.SendToAllClients(data, NetworkMessageType.LobbyStartGame, Facepunch.Steamworks.Networking.SendType.Reliable);
                             gameStarted = true;
                         }
                     }
@@ -102,7 +103,7 @@ namespace MastersOfTempest.Networking
             Client.Instance.Lobby.Name = Client.Instance.Username + "'s Lobby";
         }
 
-        void OnMessageLobbyStartGame(string message, ulong steamID)
+        void OnMessageLobbyStartGame(byte[] data, ulong steamID)
         {
             // Load client scene
             UnityEngine.SceneManagement.SceneManager.LoadScene(clientSceneName);

--- a/Assets/Scripts/Networking/NetworkBehaviour.cs
+++ b/Assets/Scripts/Networking/NetworkBehaviour.cs
@@ -38,10 +38,6 @@ namespace MastersOfTempest.Networking
             }
             else
             {
-                //We should remove all "physics" components on the client side: 
-                //only Server should determine all the movement;
-                RemovePhysics();
-
                 ClientManager.Instance.clientMessageEvents[networkMessageType] += OnClientMessage;
 
                 // Wait for the initialize message
@@ -202,15 +198,6 @@ namespace MastersOfTempest.Networking
         protected virtual void OnDestroyClient()
         {
             // To be overwritten by the superclass
-        }
-
-        private void RemovePhysics()
-        {
-            var rigidBodyComponent = GetComponent<Rigidbody>();
-            if(rigidBodyComponent != null)
-            {
-                Destroy(rigidBodyComponent);
-            }
         }
     }
 }

--- a/Assets/Scripts/Networking/NetworkMessages.cs
+++ b/Assets/Scripts/Networking/NetworkMessages.cs
@@ -15,6 +15,6 @@
         NoMessages = 8,
         EnvObjects = 9,
         ServerObjectList = 10,
-        StartServer = 11,
+        InitializeServer = 11,
     };
 }

--- a/Assets/Scripts/Networking/NetworkMessages.cs
+++ b/Assets/Scripts/Networking/NetworkMessages.cs
@@ -15,5 +15,6 @@
         NoMessages = 8,
         EnvObjects = 9,
         ServerObjectList = 10,
+        StartServer = 11,
     };
 }

--- a/Assets/Scripts/Networking/ServerObject.cs
+++ b/Assets/Scripts/Networking/ServerObject.cs
@@ -136,21 +136,12 @@ namespace MastersOfTempest.Networking
         }
     }
 
+    [StructLayout(LayoutKind.Sequential)]
     struct MessageServerObjectList
     {
         public int count;                                           // 4 bytes
         [MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)]
         public MessageServerObject[] messages;                      // 1160 bytes
                                                                     // 1164 bytes
-    }
-
-    public struct MessageDestroyServerObject
-    {
-        public int instanceID;
-
-        public MessageDestroyServerObject(ServerObject serverObject)
-        {
-            instanceID = serverObject.transform.GetInstanceID();
-        }
     }
 }

--- a/Assets/Scripts/Networking/ServerObject.cs
+++ b/Assets/Scripts/Networking/ServerObject.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using System.Runtime.InteropServices;
 
 namespace MastersOfTempest.Networking
 {
@@ -72,7 +74,7 @@ namespace MastersOfTempest.Networking
             }
         }
 
-        public void UpdateTransformFromMessageServerObject (MessageServerObject messageServerObject)
+        public void UpdateTransformFromMessageServerObject(MessageServerObject messageServerObject)
         {
             if (!onServer)
             {
@@ -95,18 +97,21 @@ namespace MastersOfTempest.Networking
         }
     }
 
-    [System.Serializable]
+    [StructLayout(LayoutKind.Sequential)]
     public struct MessageServerObject
     {
-        public float time;
-        public string name;
-        public string resourceName;
-        public bool hasParent;
-        public int parentInstanceID;
-        public int instanceID;
-        public Vector3 localPosition;
-        public Quaternion localRotation;
-        public Vector3 localScale;
+        public float time;                                          // 4 bytes
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 24)]
+        public string name;                                         // 24 bytes
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 36)]
+        public string resourceName;                                 // 36 bytes
+        public bool hasParent;                                      // 4 byte
+        public int parentInstanceID;                                // 4 bytes
+        public int instanceID;                                      // 4 bytes
+        public Vector3 localPosition;                               // 12 bytes
+        public Quaternion localRotation;                            // 16 bytes
+        public Vector3 localScale;                                  // 12 bytes
+                                                                    // 116 bytes
 
         public MessageServerObject(ServerObject serverObject)
         {
@@ -131,13 +136,14 @@ namespace MastersOfTempest.Networking
         }
     }
 
-    [System.Serializable]
     struct MessageServerObjectList
     {
-        public List<string> messages;
+        public int count;                                           // 4 bytes
+        [MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)]
+        public MessageServerObject[] messages;                      // 1160 bytes
+                                                                    // 1164 bytes
     }
 
-    [System.Serializable]
     public struct MessageDestroyServerObject
     {
         public int instanceID;

--- a/Assets/Scripts/Networking/ServerObject.cs
+++ b/Assets/Scripts/Networking/ServerObject.cs
@@ -16,6 +16,8 @@ namespace MastersOfTempest.Networking
 
         [Header("Client Parameters")]
         public bool interpolateOnClient = true;
+        public bool removeCollider = true;
+        public bool removeRigidbody = true;
 
         // Interpolation variables
         private MessageServerObject currentMessage;
@@ -38,6 +40,11 @@ namespace MastersOfTempest.Networking
 
                 // Register to game server
                 GameServer.Instance.RegisterAndSendMessageServerObject(this);
+            }
+            else
+            {
+                // Remove collider / rigidbody on the client because it is not needed most of the time
+                RemoveColliderAndRigidbody();
             }
         }
 
@@ -64,13 +71,26 @@ namespace MastersOfTempest.Networking
             }
         }
 
-        void OnDestroy()
+        private void RemoveColliderAndRigidbody ()
         {
-            if (onServer)
+            if (removeCollider)
             {
-                // Send destroy message
-                GameServer.Instance.serverObjects.Remove(this);
-                GameServer.Instance.SendMessageDestroyServerObject(this);
+                Collider collider = GetComponent<Collider>();
+
+                if (collider != null)
+                {
+                    Destroy(collider);
+                }
+            }
+
+            if (removeRigidbody)
+            {
+                Rigidbody rigidbody = GetComponent<Rigidbody>();
+
+                if (rigidbody != null)
+                {
+                    Destroy(rigidbody);
+                }
             }
         }
 
@@ -93,6 +113,16 @@ namespace MastersOfTempest.Networking
                     transform.localRotation = messageServerObject.localRotation;
                     transform.localScale = messageServerObject.localScale;
                 }
+            }
+        }
+
+        void OnDestroy()
+        {
+            if (onServer)
+            {
+                // Send destroy message
+                GameServer.Instance.serverObjects.Remove(this);
+                GameServer.Instance.SendMessageDestroyServerObject(this);
             }
         }
     }


### PR DESCRIPTION
- Performance improvements for ServerObjects
- StartClient on the NetworkBehaviour should now be called for all clients
- ServerObject spawning on the client should now be more reliable
- Moved RemovePhysics from the NetworkBehaviour to the ServerObject

If you want to send a lot of data over the network you could use the ClientManager class and the new ByteSerializer for structs.