### PR TITLE
Performance improvement fix

### DIFF
--- a/Assets/Scripts/Networking/GameServer.cs
+++ b/Assets/Scripts/Networking/GameServer.cs
@@ -80,9 +80,8 @@ namespace MastersOfTempest.Networking
 
             foreach (ServerObject serverObject in serverObjects.Values)
             {
-                if (!onlySendChangedTransforms || serverObject.transform.hasChanged)
+                if (!onlySendChangedTransforms || serverObject.HasChanged())
                 {
-                    serverObject.transform.hasChanged = false;
                     KeyValuePair<int, ServerObject> serverObjectToAdd = new KeyValuePair<int, ServerObject>(GetHierarchyDepthOfTransform(serverObject.transform, 0), serverObject);
                     serverObjectsToSend.Add(serverObjectToAdd);
                 }

--- a/Assets/Scripts/Networking/ServerObject.cs
+++ b/Assets/Scripts/Networking/ServerObject.cs
@@ -37,6 +37,10 @@ namespace MastersOfTempest.Networking
         private Dictionary<int, Action<byte[], ulong>> networkBehaviourEvents = new Dictionary<int, Action<byte[], ulong>>();
         private Dictionary<int, Action<ulong>> networkBehaviourInitializedEvents = new Dictionary<int, Action<ulong>>();
 
+        private Vector3 lastLocalPosition;
+        private Quaternion lastLocalRotation;
+        private Vector3 lastLocalScale;
+
         void Start()
         {
             if (onServer)
@@ -109,6 +113,18 @@ namespace MastersOfTempest.Networking
                     Destroy(r);
                 }
             }
+        }
+
+        public bool HasChanged ()
+        {
+            bool changed = (transform.localPosition != lastLocalPosition) | (transform.localRotation != lastLocalRotation) | (transform.localScale != lastLocalScale);
+
+            // Save new values
+            lastLocalPosition = transform.localPosition;
+            lastLocalRotation = transform.localRotation;
+            lastLocalScale = transform.localScale;
+
+            return changed;
         }
 
         public void UpdateTransformFromMessageServerObject(MessageServerObject messageServerObject)


### PR DESCRIPTION
ServerObjects that are children will no longer be updated when only their parent moved (because the local position/rotation/scale stays the same). This should improve performance a lot.